### PR TITLE
fixing opening of file descriptors in server.py

### DIFF
--- a/motioneye/server.py
+++ b/motioneye/server.py
@@ -68,9 +68,9 @@ class Daemon(object):
         # redirect standard file descriptors
         sys.stdout.flush()
         sys.stderr.flush()
-        si = file('/dev/null', 'r')
-        so = file('/dev/null', 'a+')
-        se = file('/dev/null', 'a+', 0)
+        si = open('/dev/null', 'r')
+        so = open('/dev/null', 'a+')
+        se = open('/dev/null', 'ab+', 0)
         os.dup2(si.fileno(), sys.stdin.fileno())
         os.dup2(so.fileno(), sys.stdout.fileno())
         os.dup2(se.fileno(), sys.stderr.fileno())


### PR DESCRIPTION
as described in the object, I have bumped in this error when launching motioneye with python 3.7 :

```
root@275360fc3a48:~ $ /etc/init.d/motioneye start
 * Starting motionEye server                                                                                                                                                                  Traceback (most recent call last):
  File "/usr/local/bin/meyectl", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/motioneye/meyectl.py", line 259, in main
    server.main(arg_parser, sys.argv[2:], command[:-6])
  File "/usr/local/lib/python3.7/dist-packages/motioneye/server.py", line 436, in main
    daemon.start()
  File "/usr/local/lib/python3.7/dist-packages/motioneye/server.py", line 110, in start
    self.daemonize()
  File "/usr/local/lib/python3.7/dist-packages/motioneye/server.py", line 71, in daemonize
    si = file('/dev/null', 'r')
NameError: name 'file' is not defined
```
the patch fixes this error. Please review it and in case merge it please...