### PR TITLE
Fix Python 3 compatability issues:

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -140,7 +140,7 @@ _MOTION_POST_TO_PRE_42_OPTIONS_MAPPING = {
     'picture_output_motion': 'output_debug_pictures',
     'picture_quality': 'quality',
     'netcam_use_tcp': 'rtsp_uses_tcp',
-    'text_scale': lambda v, data: {'text_double': True if v > 1 else False},
+    'text_scale': lambda v, data: {'text_double': True if int(v) > 1 else False},
     'webcontrol_interface': lambda v, data: {'webcontrol_html_output': bool(v)},
     'webcontrol_parms': None
 }
@@ -642,7 +642,7 @@ def main_ui_to_dict(ui):
 
     if ui.get('admin_password') is not None:
         if ui['admin_password']:
-            data['@admin_password'] = hashlib.sha1(ui['admin_password']).hexdigest()
+            data['@admin_password'] = hashlib.sha1(ui['admin_password'].encode('utf-8')).hexdigest()
 
         else:
             data['@admin_password'] = ''

--- a/motioneye/diskctl.py
+++ b/motioneye/diskctl.py
@@ -140,7 +140,7 @@ def _list_disks_dev_by_id():
             partition['partitions'] = [dict(partition)]
 
     # prepare flat list of disks
-    disks = disks_by_dev.values()
+    disks = list(disks_by_dev.values())
     disks.sort(key=lambda d: d['vendor'])
     
     for disk in disks:

--- a/motioneye/utils.py
+++ b/motioneye/utils.py
@@ -611,7 +611,7 @@ def test_rtsp_url(data, callback):
         called[0] = True
         cameras = []
         if identifier:
-            identifier = ' ' + identifier.decode()
+            identifier = ' ' + identifier
             
         else:
             identifier = ''
@@ -844,7 +844,7 @@ def build_editable_mask_file(camera_id, mask_lines, capture_width=None, capture_
                   (camera_id, width, height))
 
     # horizontal rectangles
-    nx = MASK_WIDTH  # number of rectangles
+    nx = int(MASK_WIDTH)  # number of rectangles
     if width % nx:
         nx -= 1
         rx = width % nx  # remainder
@@ -855,7 +855,7 @@ def build_editable_mask_file(camera_id, mask_lines, capture_width=None, capture_
     rw = width / nx  # rectangle width
 
     # vertical rectangles
-    ny = mask_height = height * MASK_WIDTH / width  # number of rectangles
+    ny = mask_height = int(height * MASK_WIDTH / width)  # number of rectangles
     if height % ny:
         ny -= 1
         ry = height % ny  # remainder
@@ -950,7 +950,7 @@ def parse_editable_mask_file(camera_id, capture_width=None, capture_height=None)
     pixels = list(im.getdata())
 
     # horizontal rectangles
-    nx = MASK_WIDTH  # number of rectangles
+    nx = int(MASK_WIDTH)  # number of rectangles
     if width % nx:
         nx -= 1
         rx = width % nx  # remainder
@@ -961,7 +961,7 @@ def parse_editable_mask_file(camera_id, capture_width=None, capture_height=None)
     rw = width / nx  # rectangle width
 
     # vertical rectangles
-    ny = height * MASK_WIDTH / width  # number of rectangles
+    ny = int(height * MASK_WIDTH / width)  # number of rectangles
     if height % ny:
         ny -= 1
         ry = height % ny  # remainder


### PR DESCRIPTION
config.py:
    * need to explicitly encode input to hashlib.sha1 as UTF-8
    * explicitly type 'v' as 'int' fro text_scale

utils.py:
    * remove call to obsolete decode() method
    * editable masks: explicitly type nx, ny dimensions as 'int'

diskctl.py:
    * disks_by_dev.values() no longer returns list so needs to be converted

mediafiles.py:
    * change from StringIO to BytesIO fro binary file manipulation